### PR TITLE
Fix calculation of logits for training loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ Our aim is to create an easy to use Lightning implementation of OpenAI's clip tr
   - [ ] Gradient checkpointing
   - [ ] Half-precision Adam statistics
   - [ ] Half-precision stochastically rounded text encoder weights
+  - [ ] Self-distillation


### PR DESCRIPTION
The embeddings must be l2 normalized before calculating the logits.  This fix corrects both the loss that is logged and the training loss.  The validation loss was already correct, as the model forward function normalizes the embeddings before computing the logits.